### PR TITLE
feat(): Add sorting option to have consistent hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ var merge = new MergePlugin({
   search: 'glob' || ['globs',...],
   skip: 'substr' || /regexp/ || [ 'substr', /regex/, ...],
   group: '[name]',
+  sort: true || false, // Default false
   name: '[name].[hash].[ext]',
 });
 ```
@@ -203,7 +204,7 @@ loaders: [
 
 Files may be grouped by simple criterion. Grouping criterion is
 specified in `group` loader param. If `group` param is not
-specified than will be only one common group where will be 
+specified than will be only one common group where will be
 all files joined togather.
 
 Grouping criteria formed by template placeholders described

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function MergePlugin(options) {
   };
 
   options.save = function(common) {
-    return JSON.stringify(common);
+    return JSON.stringify(common, options.sort ? Object.keys(common).sort() : null);
   };
 
   JoinPlugin.call(this,options);


### PR DESCRIPTION
The project I am working on uses `merge-webpack-plugin` to merge language files from different modules and we noticed that the hash is different even though the content of translation files does not change. Thus sorting the object by keys before it is stringified would help to keep consistent hash.