### PR TITLE
fix(): Fix shallow sorting to retain nested properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,15 @@ function MergePlugin(options) {
   };
 
   options.save = function(common) {
-    return JSON.stringify(common, options.sort ? Object.keys(common).sort() : null);
+    if (options.sort) {
+      common = Object.keys(common)
+        .sort()
+        .reduce((sorted, key) => {
+          sorted[key] = common[key];
+          return sorted;
+        }, {});
+    }
+    return JSON.stringify(common);
   };
 
   JoinPlugin.call(this,options);

--- a/test/package/webpack.config.js
+++ b/test/package/webpack.config.js
@@ -19,6 +19,7 @@ module.exports = {
   },
   plugins: [
     new MergePlugin({
+      sort: true,
       search: './src/**/*.yaml',
     })
   ]


### PR DESCRIPTION
Using `replacer` property of `JSON.stringify` was not very good decision. With sorted keys passed as replacer property all nested values of the `common` object were lost:
```js
const common = {
  key1: "value1",
  key3: "value3",
  key4: {
    nested1: "nestedValue1",
    nested3: "nestedValue3",
    nested2: "nestedValue2"
  },
  key2: "value2"
};
console.log(JSON.stringify(common, Object.keys(common).sort(), 2));
```
results into:
```
{
  "key1": "value1",
  "key2": "value2",
  "key3": "value3",
  "key4": {}
}
```

With the fix shallow sorting does not omit nested values and the final results looks like this:
```
{
  "key1": "value1",
  "key2": "value2",
  "key3": "value3",
  "key4": {
    "nested1": "nestedValue1",
    "nested3": "nestedValue3",
    "nested2": "nestedValue2"
  }
}
```

This should be enough to create a consistent hash (deep sorting is not needed) as the original issue with hash inconsistency stemmed from randomness when reading files that are being merged.